### PR TITLE
Implement extension method and cleanups

### DIFF
--- a/IronLog.File/FileLoggerExtensions.cs
+++ b/IronLog.File/FileLoggerExtensions.cs
@@ -1,0 +1,21 @@
+using IronLog.File.Loggers;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace IronLog.File
+{
+    public static class FileLoggerExtensions
+    {
+        public static ILoggingBuilder AddFileLogger(this ILoggingBuilder builder, IConfiguration config)
+        {
+            builder.Services.AddSingleton<ILoggerProvider>(sp =>
+            {
+                var env = sp.GetService<IHostEnvironment>();
+                return new FileLoggerProvider(config, env);
+            });
+            return builder;
+        }
+    }
+}

--- a/IronLog.File/FileLoggerProvider.cs
+++ b/IronLog.File/FileLoggerProvider.cs
@@ -1,9 +1,10 @@
-﻿using IronLog.File.Loggers;
+using IronLog.File.Loggers;
 using IronLog.File.Model;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using System;
+using System.IO;
 
 namespace IronLog.File
 {
@@ -26,10 +27,11 @@ namespace IronLog.File
 
             if (options.Path.StartsWith("\\"))
             {
+                var relativePath = options.Path.TrimStart('\\');
                 if (_env != null)
-                    options.Path = _env.ContentRootPath + options.Path;
+                    options.Path = Path.Combine(_env.ContentRootPath, relativePath);
                 else
-                    options.Path = System.IO.Directory.GetCurrentDirectory() + options.Path;
+                    options.Path = Path.Combine(System.IO.Directory.GetCurrentDirectory(), relativePath);
             }
 
             return options.LoggerType switch

--- a/IronLog.File/Loggers/IronJsonLogger.cs
+++ b/IronLog.File/Loggers/IronJsonLogger.cs
@@ -1,4 +1,4 @@
-﻿using IronLog.File.Model;
+using IronLog.File.Model;
 using Microsoft.Extensions.Logging;
 using System;
 using System.IO;
@@ -60,9 +60,9 @@ namespace IronLog.File.Loggers
             if (!Directory.Exists(Path))
                 Directory.CreateDirectory(Path);
 
-            using var streamWriter = new StreamWriter($"{ Path }\\{ FileName }", true);
+            var filePath = Path.Combine(Path, FileName);
+            using var streamWriter = new StreamWriter(filePath, true);
             streamWriter.WriteLineAsync(message).Wait();
-            streamWriter.Close();
         }
     }
 }

--- a/IronLog.File/Loggers/IronTxtLogger.cs
+++ b/IronLog.File/Loggers/IronTxtLogger.cs
@@ -1,4 +1,4 @@
-﻿using IronLog.File.Model;
+using IronLog.File.Model;
 using Microsoft.Extensions.Logging;
 using System;
 using System.IO;
@@ -65,9 +65,9 @@ namespace IronLog.File.Loggers
             if (!Directory.Exists(Path))
                 Directory.CreateDirectory(Path);
 
-            using var streamWriter = new StreamWriter($"{ Path }\\{ FileName }", true);
+            var filePath = Path.Combine(Path, FileName);
+            using var streamWriter = new StreamWriter(filePath, true);
             streamWriter.WriteLineAsync(message).Wait();
-            streamWriter.Close();
         }
     }
 }

--- a/IronLog.File/Model/FileLoggerOptions.cs
+++ b/IronLog.File/Model/FileLoggerOptions.cs
@@ -1,4 +1,4 @@
-﻿namespace IronLog.File.Model
+namespace IronLog.File.Model
 {
     public class FileLoggerOptions
     {
@@ -11,3 +11,4 @@
         public string DateFormat { get; set; }
     }
 }
+

--- a/IronLog.File/Model/SplitType.cs
+++ b/IronLog.File/Model/SplitType.cs
@@ -1,4 +1,4 @@
-﻿namespace IronLog.File.Model
+namespace IronLog.File.Model
 {
     public enum SplitType
     {

--- a/IronLog.Test/UnitTest.cs
+++ b/IronLog.Test/UnitTest.cs
@@ -1,9 +1,7 @@
 using IronLog.File;
-using IronLog.File.Model;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace IronLog.Test
@@ -15,9 +13,12 @@ namespace IronLog.Test
         public void MainTest()
         {
             var config = new ConfigurationBuilder().AddJsonFile("appsettings.json").Build();
-            var factory = new FileLoggerProvider(config, null);
 
-            var logger = factory.CreateLogger("SampleController");
+            var services = new ServiceCollection();
+            services.AddLogging(builder => builder.AddFileLogger(config));
+
+            using var provider = services.BuildServiceProvider();
+            var logger = provider.GetRequiredService<ILogger<UnitTest>>();
             logger.LogInformation("Sample 1");
             logger.LogDebug("Sample 2");
             logger.LogError("Sample 3");

--- a/IronLog.Test/appsettings.json
+++ b/IronLog.Test/appsettings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "IronLogOptions": {
     "LoggerType": "txt", //json 
     "Path": "\\Log",

--- a/README.md
+++ b/README.md
@@ -10,19 +10,11 @@
 
 `<PackageReference Include="IronLog.File" Version="1.0.2" />`
 
-######  Startup.cs 
+######  Startup.cs
 ```csharp
-public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILoggerFactory loggerFactory)
-{ 
-	loggerFactory.AddProvider(new FileLoggerProvider(Configuration)); 
-	app.UseHttpsRedirection();
-	app.UseStaticFiles(); 
-	app.UseRouting(); 
-	app.UseEndpoints(endpoints =>
-	{
-		endpoints.MapBlazorHub();
-		endpoints.MapFallbackToPage("/_Host");
-	});
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddLogging(builder => builder.AddFileLogger(Configuration));
 }
 ```
 ######  appsettings.json


### PR DESCRIPTION
## Summary
- improve path handling for the logger using `Path.Combine`
- remove redundant `Close()` calls
- add `AddFileLogger` extension for easier registration
- update README to show new extension usage
- refactor unit test to use the extension
- normalize file encodings

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*