### PR TITLE
Add MySql logger

### DIFF
--- a/IronLog.MySql/IronLog.MySql.csproj
+++ b/IronLog.MySql/IronLog.MySql.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Description>.Net Core MySql Logger.</Description>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/Sarpilhan/IronLog</RepositoryUrl>
+    <PackageTags>.net Core, Logger, MySql</PackageTags>
+    <FileVersion>1.0.0.0</FileVersion>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <Version>1.0.0</Version>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+    <PackageReference Include="MySql.Data" Version="8.0.33" />
+  </ItemGroup>
+
+</Project>

--- a/IronLog.MySql/Loggers/IronMySqlLogger.cs
+++ b/IronLog.MySql/Loggers/IronMySqlLogger.cs
@@ -1,0 +1,44 @@
+using IronLog.MySql.Model;
+using Microsoft.Extensions.Logging;
+using MySql.Data.MySqlClient;
+using System;
+
+namespace IronLog.MySql.Loggers
+{
+    public class IronMySqlLogger : ILogger
+    {
+        private readonly MySqlLoggerOptions _options;
+        private readonly string _categoryName;
+
+        public IronMySqlLogger(MySqlLoggerOptions options, string categoryName)
+        {
+            _options = options;
+            _categoryName = categoryName;
+        }
+
+        public IDisposable BeginScope<TState>(TState state) => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            try
+            {
+                using var connection = new MySqlConnection(_options.ConnectionString);
+                connection.Open();
+                using var command = connection.CreateCommand();
+                command.CommandText = $"INSERT INTO {_options.TableName} (Date, Level, Logger, Message, Exception) VALUES (@date, @level, @logger, @message, @exception)";
+                command.Parameters.AddWithValue("@date", DateTime.Now);
+                command.Parameters.AddWithValue("@level", logLevel.ToString());
+                command.Parameters.AddWithValue("@logger", _categoryName);
+                command.Parameters.AddWithValue("@message", formatter(state, exception));
+                command.Parameters.AddWithValue("@exception", exception?.InnerException?.Message);
+                command.ExecuteNonQuery();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+            }
+        }
+    }
+}

--- a/IronLog.MySql/Model/MySqlLoggerOptions.cs
+++ b/IronLog.MySql/Model/MySqlLoggerOptions.cs
@@ -1,0 +1,9 @@
+namespace IronLog.MySql.Model
+{
+    public class MySqlLoggerOptions
+    {
+        public const string MySqlLoggerOption = "MySqlLogOptions";
+        public string ConnectionString { get; set; }
+        public string TableName { get; set; }
+    }
+}

--- a/IronLog.MySql/MySqlLoggerExtensions.cs
+++ b/IronLog.MySql/MySqlLoggerExtensions.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace IronLog.MySql
+{
+    public static class MySqlLoggerExtensions
+    {
+        public static ILoggingBuilder AddMySqlLogger(this ILoggingBuilder builder, IConfiguration config)
+        {
+            builder.Services.AddSingleton<ILoggerProvider>(sp => new MySqlLoggerProvider(config));
+            return builder;
+        }
+    }
+}

--- a/IronLog.MySql/MySqlLoggerProvider.cs
+++ b/IronLog.MySql/MySqlLoggerProvider.cs
@@ -1,0 +1,42 @@
+using IronLog.MySql.Loggers;
+using IronLog.MySql.Model;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using System;
+
+namespace IronLog.MySql
+{
+    public class MySqlLoggerProvider : ILoggerProvider
+    {
+        private bool isDisposed;
+        private readonly IConfiguration _config;
+
+        public MySqlLoggerProvider(IConfiguration config)
+        {
+            _config = config;
+        }
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            var options = new MySqlLoggerOptions();
+            _config.GetSection(MySqlLoggerOptions.MySqlLoggerOption).Bind(options);
+            return new IronMySqlLogger(options, categoryName);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (isDisposed) return;
+            if (disposing)
+            {
+                // nothing to dispose
+            }
+            isDisposed = true;
+        }
+    }
+}

--- a/IronLog.Test/IronLog.Test.csproj
+++ b/IronLog.Test/IronLog.Test.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\IronLog.File\IronLog.File.csproj" />
+    <ProjectReference Include="..\IronLog.MySql\IronLog.MySql.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/IronLog.Test/UnitTest.cs
+++ b/IronLog.Test/UnitTest.cs
@@ -1,4 +1,5 @@
 using IronLog.File;
+using IronLog.MySql;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -24,6 +25,19 @@ namespace IronLog.Test
             logger.LogError("Sample 3");
             logger.LogTrace("Sample 4");
             logger.LogCritical("Sample 5");
+        }
+
+        [TestMethod]
+        public void MySqlTest()
+        {
+            var config = new ConfigurationBuilder().AddJsonFile("appsettings.json").Build();
+
+            var services = new ServiceCollection();
+            services.AddLogging(builder => builder.AddMySqlLogger(config));
+
+            using var provider = services.BuildServiceProvider();
+            var logger = provider.GetRequiredService<ILogger<UnitTest>>();
+            logger.LogInformation("Sql Sample 1");
         }
     }
 }

--- a/IronLog.Test/appsettings.json
+++ b/IronLog.Test/appsettings.json
@@ -1,10 +1,14 @@
 {
   "IronLogOptions": {
-    "LoggerType": "txt", //json 
+    "LoggerType": "txt", //json
     "Path": "\\Log",
     "FileNameStatic": "Log_{0}",
     "SplitFormat": "Hourly",  //Infinite, Minute, Hourly, QuarterlyDaily, HalfDay, Daily, Weekly, Monthly
     "Layout": "{date} {level} {logger}  {message} {exception}",
-    "DateFormat": "dd/MM/yyyy HH:mm:ss" 
+    "DateFormat": "dd/MM/yyyy HH:mm:ss"
+  },
+  "MySqlLogOptions": {
+    "ConnectionString": "Server=localhost;Database=Logs;Uid=root;Pwd=;",
+    "TableName": "AppLogs"
   }
 }

--- a/IronLog.sln
+++ b/IronLog.sln
@@ -5,9 +5,11 @@ VisualStudioVersion = 16.0.30320.27
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IronLog.File", "IronLog.File\IronLog.File.csproj", "{FD06BAA3-6C38-43AB-ABAF-04D8D98FF9C4}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IronLog.MySql", "IronLog.MySql\IronLog.MySql.csproj", "{8E94E819-0B9E-493F-B254-56ABE411A507}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1743EE3B-7882-44F1-9F57-FCE6B0B04F20}"
-	ProjectSection(SolutionItems) = preProject
-		README.md = README.md
+        ProjectSection(SolutionItems) = preProject
+                README.md = README.md
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IronLog.Test", "IronLog.Test\IronLog.Test.csproj", "{3BC24D1E-BBEC-4F95-9923-8E14CD5D71F2}"
@@ -21,9 +23,13 @@ Global
 		{FD06BAA3-6C38-43AB-ABAF-04D8D98FF9C4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{FD06BAA3-6C38-43AB-ABAF-04D8D98FF9C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FD06BAA3-6C38-43AB-ABAF-04D8D98FF9C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{FD06BAA3-6C38-43AB-ABAF-04D8D98FF9C4}.Release|Any CPU.Build.0 = Release|Any CPU
-		{3BC24D1E-BBEC-4F95-9923-8E14CD5D71F2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3BC24D1E-BBEC-4F95-9923-8E14CD5D71F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+               {FD06BAA3-6C38-43AB-ABAF-04D8D98FF9C4}.Release|Any CPU.Build.0 = Release|Any CPU
+               {8E94E819-0B9E-493F-B254-56ABE411A507}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+               {8E94E819-0B9E-493F-B254-56ABE411A507}.Debug|Any CPU.Build.0 = Debug|Any CPU
+               {8E94E819-0B9E-493F-B254-56ABE411A507}.Release|Any CPU.ActiveCfg = Release|Any CPU
+               {8E94E819-0B9E-493F-B254-56ABE411A507}.Release|Any CPU.Build.0 = Release|Any CPU
+               {3BC24D1E-BBEC-4F95-9923-8E14CD5D71F2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+               {3BC24D1E-BBEC-4F95-9923-8E14CD5D71F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3BC24D1E-BBEC-4F95-9923-8E14CD5D71F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3BC24D1E-BBEC-4F95-9923-8E14CD5D71F2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection

--- a/README.md
+++ b/README.md
@@ -52,3 +52,31 @@ public class HomeController : Controller
 }
 ```
 
+
+# IronLog.MySql
+
+.Net Core MySql Logger Extension
+
+## Setup
+
+`Install-Package IronLog.MySql -Version 1.0.0`
+
+`dotnet add package IronLog.MySql --version 1.0.0`
+
+`<PackageReference Include="IronLog.MySql" Version="1.0.0" />`
+
+######  Startup.cs
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddLogging(builder => builder.AddMySqlLogger(Configuration));
+}
+```
+######  appsettings.json
+```json
+"MySqlLogOptions": {
+    "ConnectionString": "server=.;database=Logs;uid=root;pwd=pass;",
+    "TableName": "AppLogs"
+}
+```
+


### PR DESCRIPTION
## Summary
- add IronLog.MySql project for logging to MySQL
- register MySql logger in solution and tests
- extend README with MySql instructions
- update tests and configuration for MySql

## Testing
- `dotnet test` *(fails: `dotnet` not found)*